### PR TITLE
rsync method to share source code to html folder

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -8,7 +8,7 @@ MYSQL_ROOT_PASSWORD=changeme1234
 # --------------------------------------------
 # REQUIRED: BASIC APP SETTINGS
 # --------------------------------------------
-APP_ENV=develop
+APP_ENV=production
 APP_DEBUG=false
 # please regenerate the APP_KEY value by calling `docker-compose run --rm snipeit bash` and then `php artisan key:generate --show` and then copy paste the value here
 APP_KEY=base64:3ilviXqB9u6DX1NRcyWGJ+sjySF+H18CPDGb3+IVwMQ=

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,7 @@
 FROM alpine:3.14.2
-# Apache + PHP
+# Apache + PHP and rsync
 RUN  apk add --no-cache \
+        rsync \
         apache2 \
         php7 \
         php7-common \
@@ -76,6 +77,10 @@ RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --working-dir=/var/ww
 USER root
 
 VOLUME ["/var/lib/snipeit"]
+
+#Add rsync of files as a cronjob
+ADD crontab.txt /crontab.txt
+RUN /usr/bin/crontab /crontab.txt
 
 # Entrypoints
 COPY docker/entrypoint_alpine.sh /entrypoint.sh

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,0 +1,2 @@
+#rsync files each minute
+* * * * * /usr/bin/rsync -avz /tmp/ /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     ports:
     - "8000:80"
     volumes:
-    - ./logs:/var/www/html/storage/logs
+    - ./logs:/var/www/logs
+    - ./:/tmp/
     depends_on:
     - mariadb
     - redis

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+# Configure cron, change the logic according to your requirement
+if [ "${APP_ENV}" == "production" ]
+then
+    crond -b -L /dev/stdout
+fi
+
 
 # fix key if needed
 if [ -z "$APP_KEY" ]


### PR DESCRIPTION
- share your source code to /tmp folder in the container
- install rsync on the container using docker file
- create a cronjob  that execute each minute in order to sync /tmp to /var/www/html