### PR TITLE
Mount sourcecode to var www html

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -8,7 +8,7 @@ MYSQL_ROOT_PASSWORD=changeme1234
 # --------------------------------------------
 # REQUIRED: BASIC APP SETTINGS
 # --------------------------------------------
-APP_ENV=develop
+APP_ENV=production
 APP_DEBUG=false
 # please regenerate the APP_KEY value by calling `docker-compose run --rm snipeit bash` and then `php artisan key:generate --show` and then copy paste the value here
 APP_KEY=base64:3ilviXqB9u6DX1NRcyWGJ+sjySF+H18CPDGb3+IVwMQ=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     - "8000:80"
     volumes:
     - ./logs:/var/www/html/storage/logs
+#mount html folder to workspcace with read write access
+    - ./:/var/www/html/:rw
     depends_on:
     - mariadb
     - redis

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -54,6 +54,9 @@ php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
+#add permission for the storage folder
+chmod -R 777 /var/www/html/storage
+touch /var/www/html/storage/logs/laravel.log
 chown -R apache:root /var/www/html/storage/logs/laravel.log
 
 export APACHE_LOG_DIR=/var/log/apache2

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Install dependencies
+COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --working-dir=/var/www/html
 
 # fix key if needed
 if [ -z "$APP_KEY" ]


### PR DESCRIPTION
Composer install take place in the docker file. But as as we mount the workspace to the /var/www/html this workspace is useless. 

We had to move the command to the docker entry point, then it will install the dependencies in runtime insides snipeit, after starting the container. 